### PR TITLE
Add and use PostContentValidator

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The Ritter Jekyll Experience
 
 - Process images in *_site/images* folder
 - Validate post urls
+- Validate post contents
 - Validate links inside posts (including images)
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ritter-jekyll",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "The Ritter Jekyll Experience",
   "bin": "lib/index.js",
   "files": [

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -3,6 +3,7 @@
 import path from 'path';
 import npmRun from 'npm-run';
 import winston from 'winston';
+import PostContentValidator from './post-content-validator';
 import PostUrlValidator from './post-url-validator';
 import ImageProcessor from './image-processor';
 import LinkChecker from './link-checker';
@@ -19,6 +20,10 @@ winston.info(`ritter-jekyll ${require('../package.json').version}`);
 winston.info('Validating post urls...');
 new PostUrlValidator().validate(postsGlob);
 winston.info('urls are valid!');
+
+winston.info('Validating post contents...');
+new PostContentValidator().validate(postsGlob);
+winston.info('post content is valid!');
 
 winston.info('Running image processor...');
 new ImageProcessor().run(`${_siteFolder}/images`).then(() => {

--- a/src/lib/post-content-validator.js
+++ b/src/lib/post-content-validator.js
@@ -1,0 +1,28 @@
+import fs from 'fs';
+import globby from 'globby';
+
+export default class PostContentValidator {
+  validate(path) {
+    const errors = [];
+    const files = globby.sync(path);
+
+    files.forEach(file => {
+      const text = fs.readFileSync(file, 'utf8');
+
+      // Look for problematic `|` character in
+      // [abc](https://example.org "A | B")
+      const verticalBarProblematicLinks = text.match(/\[.*\]\([\w:\/.]*\s*\".*\|.*\"\)/gi);
+
+      if (verticalBarProblematicLinks) {
+        errors.push(file
+          + ' contains the following problematic vertical bar links:\n\n'
+          + verticalBarProblematicLinks.join('\n')
+          + '\n');
+      }
+    });
+
+    if (errors.length > 0) {
+      throw new Error(errors.join('\n'));
+    }
+  }
+}

--- a/test/fixtures/2000-01-01-post-with-problematic-vertical-bar-links-1.md
+++ b/test/fixtures/2000-01-01-post-with-problematic-vertical-bar-links-1.md
@@ -1,0 +1,2 @@
+[abc](https://example.org "A | B")
+[def](https://example.org "C | D")

--- a/test/fixtures/2000-01-01-post-with-problematic-vertical-bar-links-2.md
+++ b/test/fixtures/2000-01-01-post-with-problematic-vertical-bar-links-2.md
@@ -1,0 +1,2 @@
+[ghi](https://example.org "G | H")
+[jkl](https://example.org "I | J")

--- a/test/post-content-validator.tests.js
+++ b/test/post-content-validator.tests.js
@@ -1,0 +1,29 @@
+import test from 'ava';
+import path from 'path';
+
+import PostContentValidator from '../src/lib/post-content-validator';
+
+test('validate should not throw for no files', t => {
+  t.notThrows(() => new PostContentValidator()
+    .validate(path.resolve(__dirname, './fixtures/**.not-md')));
+});
+
+test('validate should throw for `|` link issues', t => {
+  const error = t.throws(() => new PostContentValidator()
+    .validate(path.resolve(__dirname, './fixtures/2000-01-01-post-with-problematic-vertical-bar-links*.md')));
+
+  t.true(error.message.includes(`2000-01-01-post-with-problematic-vertical-bar-links-1.md contains the following problematic vertical bar links:
+
+[abc](https://example.org "A | B")
+[def](https://example.org "C | D")`));
+
+  t.true(error.message.includes(`2000-01-01-post-with-problematic-vertical-bar-links-2.md contains the following problematic vertical bar links:
+
+[ghi](https://example.org "G | H")
+[jkl](https://example.org "I | J")`));
+});
+
+test('validate should not throw for valid links', t => {
+  t.notThrows(() => new PostContentValidator()
+    .validate(path.resolve(__dirname, './fixtures/2000-01-01-post-with-valid-links.md')));
+});


### PR DESCRIPTION
Resolves #28.

- Add and use `PostContentValidator` to look for problematic `|` character in `[abc](https://example.org "A | B")`
- Version **0.4.0**