### PR TITLE
Upgrade globby to ^8.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "dependencies": {
     "front-matter": "^2.1.2",
-    "globby": "^6.0.0",
+    "globby": "^8.0.1",
     "winston": "^2.2.0",
     "winston-timer": "^0.1.0"
   },


### PR DESCRIPTION
Internally `globby` switched from `node-glob` to `fast-glob` in https://github.com/sindresorhus/globby/releases/tag/v8.0.0.